### PR TITLE
Fix Docker build permission issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,9 @@ ARG GROUP_ID=1000
 RUN groupadd -g ${GROUP_ID} builder && \
     useradd -u ${USER_ID} -g builder -m builder && \
     mkdir -p /src && \
-    chown builder:builder /src
+    mkdir -p /home/builder/build && \
+    chown builder:builder /src && \
+    chown builder:builder /home/builder/build
 
 # Switch to non-root user
 USER builder

--- a/build-package.sh
+++ b/build-package.sh
@@ -22,9 +22,9 @@ docker build \
 echo "Running package build..."
 docker run --rm \
     -v "$(pwd):/src" \
-    -w /src \
+    -w /home/builder/build \
     volmix-builder \
-    bash -c "dpkg-buildpackage -us -uc && cp ../*.deb . 2>/dev/null"
+    bash -c "cp -r /src/* . && dpkg-buildpackage -us -uc && cp ../*.deb /src/ 2>/dev/null"
 
 # Check if any .deb files were generated
 debs=$(find . -maxdepth 1 -type f -name '*.deb')

--- a/build-package.sh
+++ b/build-package.sh
@@ -24,7 +24,7 @@ docker run --rm \
     -v "$(pwd):/src" \
     -w /home/builder/build \
     volmix-builder \
-    bash -c "cp -r /src/* . && dpkg-buildpackage -us -uc && cp ../*.deb /src/ 2>/dev/null"
+    bash -c "cp -r /src/. . && dpkg-buildpackage -us -uc && cp ../*.deb /src/ 2>/dev/null"
 
 # Check if any .deb files were generated
 debs=$(find . -maxdepth 1 -type f -name '*.deb')


### PR DESCRIPTION
## Summary
- Fix Docker container permission issues preventing package builds
- Create dedicated build directory in container home folder
- Copy source files before running dpkg-buildpackage to avoid root directory access

## Test plan
- [x] Run GitHub Actions workflow to verify build succeeds
- [x] Confirm .deb package is generated successfully

This resolves the `Permission denied` error when dpkg-source tries to create temporary files during package building.