### PR TITLE
Fix custom icon installation in packages

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,7 @@
 SUBDIRS = src
 
-EXTRA_DIST = autogen.sh
+# Install data files
+iconsdir = $(datadir)/volmix/icons
+icons_DATA = data/icons/sound-icon-inverted.png
+
+EXTRA_DIST = autogen.sh $(icons_DATA)

--- a/configure.ac
+++ b/configure.ac
@@ -12,4 +12,7 @@ PKG_CHECK_MODULES([GTK], [gtk+-3.0 >= 3.0.0])
 PKG_CHECK_MODULES([PULSE], [libpulse >= 0.9.16])
 PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.32.0])
 
+# Define paths for data files
+AC_SUBST(pkgdatadir, ['${datadir}/volmix'])
+
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,5 +2,5 @@ bin_PROGRAMS = volmix
 
 volmix_SOURCES = volmix.c pulse_client.c pulse_client.h
 
-volmix_CFLAGS = $(GTK_CFLAGS) $(PULSE_CFLAGS) $(GLIB_CFLAGS)
+volmix_CFLAGS = $(GTK_CFLAGS) $(PULSE_CFLAGS) $(GLIB_CFLAGS) -DDATADIR=\"$(datadir)\"
 volmix_LDADD = $(GTK_LIBS) $(PULSE_LIBS) $(GLIB_LIBS)

--- a/src/volmix.c
+++ b/src/volmix.c
@@ -294,13 +294,26 @@ static void setup_tray_icon(volmix_app_t *app)
     app->tray_icon = gtk_status_icon_new();
     
     // Load the inverted sound icon PNG (white speaker)
-    gchar *icon_path = g_build_filename("data", "icons", "sound-icon-inverted.png", NULL);
+    // Try development location first, then installed location
+    gchar *dev_icon_path = g_build_filename("data", "icons", "sound-icon-inverted.png", NULL);
+    gchar *installed_icon_path = g_build_filename(DATADIR, "volmix", "icons", "sound-icon-inverted.png", NULL);
+    gchar *icon_path = NULL;
     GError *error = NULL;
     GdkPixbuf *icon_pixbuf = NULL;
     
-    if (g_file_test(icon_path, G_FILE_TEST_EXISTS | G_FILE_TEST_IS_REGULAR)) {
+    // Check development location first
+    if (g_file_test(dev_icon_path, G_FILE_TEST_EXISTS | G_FILE_TEST_IS_REGULAR)) {
+        icon_path = g_strdup(dev_icon_path);
         icon_pixbuf = gdk_pixbuf_new_from_file_at_size(icon_path, 22, 22, &error);
     }
+    // Check installed location if development location failed
+    else if (g_file_test(installed_icon_path, G_FILE_TEST_EXISTS | G_FILE_TEST_IS_REGULAR)) {
+        icon_path = g_strdup(installed_icon_path);
+        icon_pixbuf = gdk_pixbuf_new_from_file_at_size(icon_path, 22, 22, &error);
+    }
+    
+    g_free(dev_icon_path);
+    g_free(installed_icon_path);
     
     if (icon_pixbuf) {
         gtk_status_icon_set_from_pixbuf(GTK_STATUS_ICON(app->tray_icon), icon_pixbuf);


### PR DESCRIPTION
## Problem
The custom inverted icon was working in local development builds but not in packaged releases. Packaged versions were falling back to the generic system audio icon instead of our custom white inverted speaker icon.

## Root Cause
The `data/icons/` directory was not being installed by the build system. The code was looking for the icon at a relative path that only existed in the development environment.

## Solution
### Build System Changes
- **Makefile.am**: Added icon installation rules (`iconsdir` and `icons_DATA`)
- **configure.ac**: Added pkgdatadir definition for proper path handling
- **src/Makefile.am**: Added `-DDATADIR` compiler flag to define install paths

### Code Changes  
- **src/volmix.c**: Updated icon loading to check both development and installed locations:
  1. First tries: `data/icons/sound-icon-inverted.png` (for development)
  2. Then tries: `/usr/share/volmix/icons/sound-icon-inverted.png` (for packages)
  3. Falls back to system icon if neither found

## Results
✅ **Local builds**: Continue to work with development icon path  
✅ **Packaged builds**: Now properly find and use the installed icon  
✅ **Package size**: Increased from 11KB to 72KB (icon file included)  
✅ **Icon location**: Installed to `/usr/share/volmix/icons/sound-icon-inverted.png`

## Testing
- Built and tested new package locally
- Verified icon file is properly installed in package
- Both development and packaged versions now display the custom icon

Fixes the discrepancy between local and packaged behavior.