### PR TITLE
Fix deb filename versioning by updating debian/changelog dynamically

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -11,6 +11,31 @@ echo "Building volmix Debian package..."
 echo "Architecture: $ARCHITECTURE"
 echo "Build Type: $BUILD_TYPE"
 
+# Get version from git tag or default to 1.0.0
+if git describe --tags --exact-match 2>/dev/null; then
+    VERSION=$(git describe --tags --exact-match | sed 's/^v//')
+else
+    VERSION="1.0.0"
+fi
+echo "Version: $VERSION"
+
+# Update debian/changelog with current version
+CHANGELOG_ENTRY="volmix ($VERSION-1) unstable; urgency=medium
+
+  * Release version $VERSION
+  * See git log for detailed changes
+
+ -- Chris Wage <cwage@quietlife.net>  $(date -R)
+"
+
+# Create temporary changelog with new version
+echo "$CHANGELOG_ENTRY" > debian/changelog.tmp
+if [ -f debian/changelog ]; then
+    echo "" >> debian/changelog.tmp
+    tail -n +2 debian/changelog >> debian/changelog.tmp
+fi
+mv debian/changelog.tmp debian/changelog
+
 # Build the Docker image with current user's UID/GID
 echo "Building Docker image..."
 docker build \

--- a/build-package.sh
+++ b/build-package.sh
@@ -38,7 +38,20 @@ MAINTAINER_NAME="${MAINTAINER_NAME:-Chris Wage}"
 MAINTAINER_EMAIL="${MAINTAINER_EMAIL:-cwage@quietlife.net}"
 
 # Update debian/changelog with current version
-CHANGELOG_ENTRY="$PACKAGE_NAME ($VERSION-1) unstable; urgency=medium
+# Determine next revision number for this version
+if [ -f debian/changelog ]; then
+    # Extract all revision numbers for this version, sort, and get the highest
+    LAST_REVISION=$(grep -E "^$PACKAGE_NAME \($VERSION-[0-9]+\)" debian/changelog | \
+        sed -E "s/^$PACKAGE_NAME \($VERSION-([0-9]+)\).*/\1/" | sort -n | tail -1)
+    if [ -n "$LAST_REVISION" ]; then
+        NEXT_REVISION=$((LAST_REVISION + 1))
+    else
+        NEXT_REVISION=1
+    fi
+else
+    NEXT_REVISION=1
+fi
+CHANGELOG_ENTRY="$PACKAGE_NAME ($VERSION-$NEXT_REVISION) unstable; urgency=medium
 
   * Release version $VERSION
   * See git log for detailed changes

--- a/build-package.sh
+++ b/build-package.sh
@@ -27,8 +27,11 @@ if [ -z "$PACKAGE_NAME" ]; then
 fi
 
 # Get maintainer info from environment or extract from existing changelog
-MAINTAINER_NAME="${MAINTAINER_NAME:-$(grep "^ --" debian/changelog 2>/dev/null | head -1 | sed 's/^ -- \([^<]*\) <.*/\1/' | xargs)}"
-MAINTAINER_EMAIL="${MAINTAINER_EMAIL:-$(grep "^ --" debian/changelog 2>/dev/null | head -1 | sed 's/.*<\([^>]*\)>.*/\1/')}"
+MAINTAINER_LINE=$(grep "^ --" debian/changelog 2>/dev/null | head -1)
+if [[ "$MAINTAINER_LINE" =~ ^\ \-\-\ ([^<]+)\ <([^>]+)> ]]; then
+    MAINTAINER_NAME="${MAINTAINER_NAME:-${BASH_REMATCH[1]}}"
+    MAINTAINER_EMAIL="${MAINTAINER_EMAIL:-${BASH_REMATCH[2]}}"
+fi
 
 # Fallback to defaults if extraction fails
 MAINTAINER_NAME="${MAINTAINER_NAME:-Chris Wage}"

--- a/build-package.sh
+++ b/build-package.sh
@@ -56,7 +56,7 @@ CHANGELOG_ENTRY="$PACKAGE_NAME ($VERSION-$NEXT_REVISION) unstable; urgency=mediu
   * Release version $VERSION
   * See git log for detailed changes
 
- -- $MAINTAINER_NAME <$MAINTAINER_EMAIL>  $(date -R)
+ -- $MAINTAINER_NAME <$MAINTAINER_EMAIL> $(date -R)
 "
 
 # Create temporary changelog with new version


### PR DESCRIPTION
## Summary
- Extract version from git tag in build-package.sh
- Generate proper debian/changelog entry with current version  
- Ensures .deb files have correct version numbers in filename
- Preserves existing changelog history

## Test plan
- [ ] Test local build generates correct version filename
- [ ] Test release workflow generates versioned filenames
- [ ] Verify changelog format is correct