### PR TITLE
Fix syntax error in build script regex pattern

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -28,7 +28,7 @@ fi
 
 # Get maintainer info from environment or extract from existing changelog
 MAINTAINER_LINE=$(grep "^ --" debian/changelog 2>/dev/null | head -1)
-if [[ "$MAINTAINER_LINE" =~ ^\ \-\-\ ([^<]+)\ <([^>]+)> ]]; then
+if [[ "$MAINTAINER_LINE" =~ ^\ \-\-\ ([^\<]+)\ \<([^\>]+)\> ]]; then
     MAINTAINER_NAME="${MAINTAINER_NAME:-${BASH_REMATCH[1]}}"
     MAINTAINER_EMAIL="${MAINTAINER_EMAIL:-${BASH_REMATCH[2]}}"
 fi


### PR DESCRIPTION
Fixes the build failure caused by unescaped angle brackets in the regex pattern on line 31.

**Error**: 

**Fix**: Escape the angle brackets  in the regex pattern to avoid shell redirection conflicts.