### PR TITLE
Remove ARM64 build from release workflow

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
       
-    # Build packages for multiple architectures in parallel
+    # Build package for amd64 only
     - name: Build amd64 package
       run: |
         echo "Building amd64 package..."
@@ -48,22 +48,6 @@ jobs:
           exit 1
         fi
         mv "${files[@]}" packages/amd64/
-        shopt -u nullglob
-        
-    - name: Build arm64 package  
-      run: |
-        echo "Building arm64 package..."
-        ./build-package.sh "arm64" "release"
-        mkdir -p packages/arm64
-        
-        # Move build artifacts with proper error handling
-        shopt -s nullglob
-        files=( *.deb *.changes *.buildinfo )
-        if [ ${#files[@]} -eq 0 ]; then
-          echo "ERROR: No build artifacts (*.deb, *.changes, *.buildinfo) found for arm64." >&2
-          exit 1
-        fi
-        mv "${files[@]}" packages/arm64/
         shopt -u nullglob
         
     - name: Collect all packages


### PR DESCRIPTION
Fixes the issue where two amd64 packages were being generated instead of one amd64 and one arm64 package.

**Problem**: The ARM64 build step was not actually cross-compiling - it was building another amd64 package, resulting in:
- `volmix_1.0.5-1_amd64.deb` (from amd64 build)  
- `volmix_1.0.5-2_amd64.deb` (from arm64 build, but still amd64 architecture)

**Solution**: Remove ARM64 build step until proper cross-compilation is implemented.

**Result**: Clean single amd64 package per release.